### PR TITLE
Added XmlElement attribute to Author property so it is correctly deserialized.

### DIFF
--- a/Nager.AmazonProductAdvertising/Model/AmazonResult.cs
+++ b/Nager.AmazonProductAdvertising/Model/AmazonResult.cs
@@ -333,6 +333,7 @@ namespace Nager.AmazonProductAdvertising.Model
         public string AspectRatio { get; set; }
         public string AudienceRating { get; set; }
         public string[] AudioFormat { get; set; }
+        [XmlElement("Author")]
         public string[] Author { get; set; }
         public string Binding { get; set; }
         public string Brand { get; set; }


### PR DESCRIPTION
The XML response has multiple Author elements, not nested in a parent list element, so needs the XmlElement attribute to deserialize correctly.

I suspect there may be other properties in ItemAttributes that require similar attributes.