### PR TITLE
Interface + async support

### DIFF
--- a/Nager.AmazonProductAdvertising/AmazonWrapper.cs
+++ b/Nager.AmazonProductAdvertising/AmazonWrapper.cs
@@ -6,7 +6,7 @@ using System.Net;
 
 namespace Nager.AmazonProductAdvertising
 {
-    public class AmazonWrapper
+    public partial class AmazonWrapper : IAmazonWrapper
     {
         private AmazonAuthentication _authentication;
         private AmazonEndpoint _endpoint;

--- a/Nager.AmazonProductAdvertising/AmazonWrapperAsync.cs
+++ b/Nager.AmazonProductAdvertising/AmazonWrapperAsync.cs
@@ -2,9 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nager.AmazonProductAdvertising

--- a/Nager.AmazonProductAdvertising/AmazonWrapperAsync.cs
+++ b/Nager.AmazonProductAdvertising/AmazonWrapperAsync.cs
@@ -1,0 +1,112 @@
+﻿using Nager.AmazonProductAdvertising.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nager.AmazonProductAdvertising
+{
+    public partial class AmazonWrapper : IAmazonWrapper
+    {
+        /// <summary>
+        /// ItemLookup
+        /// </summary>
+        /// <param name="articleNumber">ASIN, EAN, GTIN, ISBN</param>
+        /// <param name="responseGroup"></param>
+        /// <returns></returns>
+        public Task<ItemLookupResponse> LookupAsync(string articleNumber, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large)
+        {
+            return this.LookupAsync(new string[1] { articleNumber }, responseGroup);
+        }
+
+        public async Task<ItemLookupResponse> LookupAsync(IList<string> articleNumbers, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large)
+        {
+            var requestParams = ItemLookupOperation(articleNumbers, responseGroup);
+
+            var webResponse = await this.RequestAsync(requestParams);
+            if (webResponse.StatusCode == HttpStatusCode.OK)
+            {
+                return XmlHelper.ParseXml<ItemLookupResponse>(webResponse.Content);
+            }
+            else
+            {
+                var errorResponse = XmlHelper.ParseXml<ItemLookupErrorResponse>(webResponse.Content);
+                this.ErrorReceived?.Invoke(errorResponse);
+            }
+
+            return null;
+        }
+
+        public async Task<ItemSearchResponse> SearchAsync(string search, AmazonSearchIndex searchIndex = AmazonSearchIndex.All, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large)
+        {
+            var requestParams = ItemSearchOperation(search, searchIndex, responseGroup);
+
+            var webResponse = await this.RequestAsync(requestParams);
+            if (webResponse.StatusCode == HttpStatusCode.OK)
+            {
+                return XmlHelper.ParseXml<ItemSearchResponse>(webResponse.Content);
+            }
+            else
+            {
+                var errorResponse = XmlHelper.ParseXml<ItemSearchErrorResponse>(webResponse.Content);
+                this.ErrorReceived?.Invoke(errorResponse);
+            }
+
+            return null;
+        }
+
+        public async Task<ExtendedWebResponse> RequestAsync(AmazonOperationBase amazonOperation)
+        {
+            using (var amazonSign = new AmazonSign(this._authentication, this._endpoint))
+            {
+                var requestUri = amazonSign.Sign(amazonOperation);
+                return await SendRequestAsync(requestUri);
+            }
+        }
+
+        private async Task<ExtendedWebResponse> SendRequestAsync(string uri)
+        {
+            var request = (HttpWebRequest)WebRequest.Create(uri);
+            request.UserAgent = this._userAgent ?? "Nager.AmazonProductAdvertising";
+
+            try
+            {
+                using (var response = await request.GetResponseAsync())
+                {
+                    using (var streamReader = new StreamReader(response.GetResponseStream()))
+                    {
+                        var xml = streamReader.ReadToEnd();
+                        this.XmlReceived?.Invoke(xml);
+
+                        return new ExtendedWebResponse(HttpStatusCode.OK, xml);
+                    }
+                }
+            }
+            catch (WebException exception)
+            {
+                if (exception.Response == null)
+                {
+                    return new ExtendedWebResponse(HttpStatusCode.SeeOther, exception.Message);
+                }
+
+                using (var response = (HttpWebResponse)exception.Response)
+                {
+                    using (var streamReader = new StreamReader(response.GetResponseStream()))
+                    {
+                        var xml = streamReader.ReadToEnd();
+                        this.XmlReceived?.Invoke(xml);
+
+                        return new ExtendedWebResponse(response.StatusCode, xml);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                return new ExtendedWebResponse(HttpStatusCode.SeeOther, exception.Message);
+            }
+        }
+    }
+}

--- a/Nager.AmazonProductAdvertising/IAmazonWrapper.cs
+++ b/Nager.AmazonProductAdvertising/IAmazonWrapper.cs
@@ -21,6 +21,8 @@ namespace Nager.AmazonProductAdvertising
 
         ItemSearchResponse Search(string search, AmazonSearchIndex searchIndex = AmazonSearchIndex.All, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
 
+        ExtendedWebResponse Request(AmazonOperationBase amazonOperation);
+
         #endregion
 
 
@@ -31,6 +33,8 @@ namespace Nager.AmazonProductAdvertising
         Task<ItemLookupResponse> LookupAsync(IList<string> articleNumbers, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
 
         Task<ItemSearchResponse> SearchAsync(string search, AmazonSearchIndex searchIndex = AmazonSearchIndex.All, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
+
+        Task<ExtendedWebResponse> RequestAsync(AmazonOperationBase amazonOperation);
 
         #endregion
     }

--- a/Nager.AmazonProductAdvertising/IAmazonWrapper.cs
+++ b/Nager.AmazonProductAdvertising/IAmazonWrapper.cs
@@ -1,0 +1,37 @@
+﻿using Nager.AmazonProductAdvertising.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nager.AmazonProductAdvertising
+{
+    public interface IAmazonWrapper
+    {
+        void SetEndpoint(AmazonEndpoint amazonEndpoint);
+
+        void SetUserAgent(string userAgent);
+
+        #region "Sync Support"
+
+        ItemLookupResponse Lookup(string articleNumber, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
+
+        ItemLookupResponse Lookup(IList<string> articleNumbers, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
+
+        ItemSearchResponse Search(string search, AmazonSearchIndex searchIndex = AmazonSearchIndex.All, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
+
+        #endregion
+
+
+        #region "Async Support"
+
+        Task<ItemLookupResponse> LookupAsync(string articleNumber, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
+
+        Task<ItemLookupResponse> LookupAsync(IList<string> articleNumbers, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
+
+        Task<ItemSearchResponse> SearchAsync(string search, AmazonSearchIndex searchIndex = AmazonSearchIndex.All, AmazonResponseGroup responseGroup = AmazonResponseGroup.Large);
+
+        #endregion
+    }
+}

--- a/Nager.AmazonProductAdvertising/Nager.AmazonProductAdvertising.csproj
+++ b/Nager.AmazonProductAdvertising/Nager.AmazonProductAdvertising.csproj
@@ -45,6 +45,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AmazonDomain.cs" />
+    <Compile Include="AmazonWrapperAsync.cs" />
+    <Compile Include="IAmazonWrapper.cs" />
     <Compile Include="Model\AmazonAuthentication.cs" />
     <Compile Include="Model\AmazonBrowseNodeLookupOperation.cs" />
     <Compile Include="Model\AmazonEndpoint.cs" />


### PR DESCRIPTION
Hi,
I was needing async support for your great library and I thought you might like to have it :)

I also added an interface for AmazonWrapper (which really is a service in my opinion). This allow dependency injection and I consider it a good practise for unit testing and in general.

I chose to make a partial class with the async implementation but you could have all in one class or probably factorize some code (I did not try). 

The only real async call is -obviously- the web request. I do not think parsing needs to be asynchronous.

Also you might benefit from ModernHttpClient which is quite great for HTTP calls. But I did not want to force this choice with my PR ;)

Note that it would be nice to have the nuget definition as it allow to test the nuget package with a local repository.

Thanks again for your library!