### PR TITLE
SearchItemResponse.Success == true when PAAPI search fails with errors

### DIFF
--- a/src/Nager.AmazonProductAdvertising/AmazonProductAdvertisingClient.cs
+++ b/src/Nager.AmazonProductAdvertising/AmazonProductAdvertisingClient.cs
@@ -4,6 +4,7 @@ using Nager.AmazonProductAdvertising.Model.Paapi;
 using Nager.AmazonProductAdvertising.Model.Request;
 using Newtonsoft.Json;
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -155,7 +156,11 @@ namespace Nager.AmazonProductAdvertising
             }
 
             var amazonResponse = JsonConvert.DeserializeObject<SearchItemResponse>(response.Content, this._jsonSerializerSettingsResponse);
-            amazonResponse.Successful = true;
+            amazonResponse.Successful = (amazonResponse.SearchResult != null && amazonResponse.Errors == null);
+
+            if (amazonResponse.Errors != null)
+                amazonResponse.ErrorMessage = String.Join("\n", amazonResponse.Errors.Select(x => x.Message));
+
             return amazonResponse;
         }
 

--- a/src/Nager.AmazonProductAdvertising/Model/AmazonResponse.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/AmazonResponse.cs
@@ -4,5 +4,7 @@
     {
         public bool Successful { get; set; }
         public string ErrorMessage { get; set; }
+
+        public AmazonResponseError[] Errors { get; set; }
     }
 }

--- a/src/Nager.AmazonProductAdvertising/Model/AmazonResponseError.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/AmazonResponseError.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nager.AmazonProductAdvertising.Model
+{
+    public class AmazonResponseError
+    {
+        public string Code { get; set; }
+        public string Message { get; set; }
+    }
+}


### PR DESCRIPTION
Search using gibberish keywords (eg aefsefwdfd). The PAAPI returns the following json, but `SearchItemResponse.Success == true`.

```{
  "Errors": [
    {
      "__type": "com.amazon.paapi5#ErrorData",
      "Code": "NoResults",
      "Message": "No results found for your request."
    }
  ]
}```