### PR TITLE
Added Brand and Title for the SearchItems endpoint

### DIFF
--- a/src/Nager.AmazonProductAdvertising/AmazonProductAdvertisingClient.cs
+++ b/src/Nager.AmazonProductAdvertising/AmazonProductAdvertisingClient.cs
@@ -134,6 +134,8 @@ namespace Nager.AmazonProductAdvertising
             var request = new SearchItemRequest
             {
                 Keywords = searchRequest.Keywords,
+                Brand = searchRequest.Brand,
+                Title = searchRequest.Title,
                 Resources = searchRequest.Resources,
                 ItemPage = searchRequest.ItemPage,
                 SortBy = searchRequest.SortBy,

--- a/src/Nager.AmazonProductAdvertising/Model/Request/SearchItemRequest.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/Request/SearchItemRequest.cs
@@ -6,6 +6,8 @@ namespace Nager.AmazonProductAdvertising.Model.Request
     public class SearchItemRequest : AmazonRequest
     {
         public string Keywords { get; set; }
+        public string Brand { get; set; }
+        public string Title { get; set; }
         public int? ItemPage { get; set; }
         [JsonConverter(typeof(StringEnumConverter))]
         public SortBy? SortBy { get; set; }

--- a/src/Nager.AmazonProductAdvertising/Model/SearchRequest.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/SearchRequest.cs
@@ -3,6 +3,8 @@
     public class SearchRequest
     {
         public string Keywords { get; set; }
+        public string Brand { get; set; }
+        public string Title { get; set; }
         public int? ItemPage { get; set; }
         public SortBy? SortBy { get; set; }
         public string BrowseNodeId { get; set; }


### PR DESCRIPTION
This is just a simple addition.

I think it might make sense to refactor the query parameter and have all the search fields (brand, title, keywords; but also the currently not implemented fields) in an extra object and flatten the whole thing for sending the query to amazon. Let me know if you want me to start doing that.